### PR TITLE
Add from_node function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ where
     from_doc(&document)
 }
 
-/// Deserialize an instance of type `T` from a [`roxmltree`] document
+/// Deserialize an instance of type `T` from a [`roxmltree::Document`]
 pub fn from_doc<'de, 'input, T>(document: &'de Document<'input>) -> Result<T, Error>
 where
     T: de::Deserialize<'de>,
@@ -155,7 +155,7 @@ where
     from_node(document.root_element())
 }
 
-/// Deserialize an instance of type `T` from a [`roxmltree`] Node
+/// Deserialize an instance of type `T` from a [`roxmltree::Node`]
 pub fn from_node<'de, 'input, T>(node: Node<'de, 'input>) -> Result<T, Error>
 where
     T: de::Deserialize<'de>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,12 +152,21 @@ pub fn from_doc<'de, 'input, T>(document: &'de Document<'input>) -> Result<T, Er
 where
     T: de::Deserialize<'de>,
 {
+    from_node(document.root_element())
+}
+
+/// Deserialize an instance of type `T` from a [`roxmltree`] Node
+pub fn from_node<'de, 'input, T>(node: Node<'de, 'input>) -> Result<T, Error>
+where
+    T: de::Deserialize<'de>,
+{
     let deserializer = Deserializer {
-        source: Source::Node(document.root_element()),
+        source: Source::Node(node),
         visited: &mut HashSet::new(),
     };
     T::deserialize(deserializer)
 }
+
 
 struct Deserializer<'de, 'input, 'tmp> {
     source: Source<'de, 'input>,


### PR DESCRIPTION
This PR adds a new function `from_node` that allows deserializing from a `Node` instead of a `Document`. The `from_doc` function has been updated to use this one.

This function can be used as a workaround for #1.